### PR TITLE
Custom area names defined in .proj file

### DIFF
--- a/mage/Editors/FormConnection.cs
+++ b/mage/Editors/FormConnection.cs
@@ -1,4 +1,4 @@
-﻿using mage.Theming;
+using mage.Theming;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -68,7 +68,15 @@ namespace mage
 
             this.main = main;
             this.romStream = ROM.Stream;
-            areaNames = Version.AreaNames;
+            // get area names and rooms per area
+			if (Version.CustomAreaNames != null && Version.project != Version.ProjectState.None) // Check if there's anything written to CustomAreaNAmes and also if there's a project file loaded
+			{
+				areaNames = Version.CustomAreaNames; // If so, load custom area names
+			}
+			else
+			{
+            areaNames = Version.AreaNames;  // If not, load regular area names
+			}
 
             statuses = new Status[4];
             statusLabels = new string[4] { "", "", "", "" };

--- a/mage/Editors/FormHeader.cs
+++ b/mage/Editors/FormHeader.cs
@@ -1,4 +1,4 @@
-﻿using mage.Dialogs;
+using mage.Dialogs;
 using mage.Theming;
 using mage.Tools;
 using System;
@@ -32,7 +32,14 @@ namespace mage
             status = new Status(statusLabel_changes, button_apply);
 
             // get area names and rooms per area
-            areaNames = Version.AreaNames;
+			if (Version.CustomAreaNames != null && Version.project != Version.ProjectState.None) // Check if there's anything written to CustomAreaNAmes and also if there's a project file loaded
+			{
+				areaNames = Version.CustomAreaNames; // If so, load custom area names
+			}
+			else
+			{
+            areaNames = Version.AreaNames;  // If not, load regular area names
+			}
             roomsPerArea = Version.RoomsPerArea;
             for (int i = 0; i < areaNames.Length; i++)
             {

--- a/mage/FormEditDoor.cs
+++ b/mage/FormEditDoor.cs
@@ -1,4 +1,4 @@
-﻿using mage.Theming;
+using mage.Theming;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -153,7 +153,15 @@ namespace mage
 
         private void DisplayInfo(Door src)
         {
-            areaNames = Version.AreaNames;
+            // get area names and rooms per area
+			if (Version.CustomAreaNames != null && Version.project != Version.ProjectState.None) // Check if there's anything written to CustomAreaNAmes and also if there's a project file loaded
+			{
+				areaNames = Version.CustomAreaNames; // If so, load custom area names
+			}
+			else
+			{
+            areaNames = Version.AreaNames;  // If not, load regular area names
+			}
             label_srcArea.Text = areaNames[src.areaID];
             label_srcRoom.Text = Hex.ToString(src.srcRoom);
             label_srcDoor.Text = Hex.ToString(src.doorNum);

--- a/mage/FormMain.cs
+++ b/mage/FormMain.cs
@@ -1322,7 +1322,14 @@ namespace mage
             menuItem_motherShipHatches.Visible = menuItem_motherShipHatches.Enabled = !Version.IsMF;
 
             // get area names and rooms per area
-            areaNames = Version.AreaNames;
+			if (Version.CustomAreaNames != null && Version.project != Version.ProjectState.None) // Check if there's anything written to CustomAreaNAmes and also if there's a project file loaded
+			{
+				areaNames = Version.CustomAreaNames; // If so, load custom area names
+			}
+			else
+			{
+            areaNames = Version.AreaNames;  // If not, load regular area names
+			}
             roomsPerArea = Version.RoomsPerArea;
             comboBox_area.Items.Clear();
             comboBox_area.Items.AddRange(areaNames);

--- a/mage/Version.cs
+++ b/mage/Version.cs
@@ -1,4 +1,4 @@
-﻿using mage.Properties;
+using mage.Properties;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -14,12 +14,13 @@ namespace mage
         private static ByteStream romStream;
 
         // project related
-        private enum ProjectState { None, New, Exists }
-        private static ProjectState project;
+        public enum ProjectState { None, New, Exists }		// Publicized these for a check in FormMain.cs
+        public static ProjectState project;					// Publicized these for a check in FormMain.cs
         private static string VersionCreated { get; set; }
         private static DateTime DateCreated { get; set; }
         private static string VersionModified { get; set; }
         private static DateTime DateModified { get; set; }
+		public static string[] CustomAreaNames { get; set; }	// Custom Area Names from project file, if one exists
 
         public static void LoadProject(string filename)
         {
@@ -110,6 +111,10 @@ namespace mage
             sw.WriteLine("NumOfAnimGfx=" + Convert.ToString(NumOfAnimGfx, 16).ToUpper());
             sw.WriteLine("NumOfAnimPalettes=" + Convert.ToString(NumOfAnimPalettes, 16).ToUpper());
             sw.WriteLine("NumOfSpritesets=" + Convert.ToString(NumOfSpritesets, 16).ToUpper());
+			sw.WriteLine();
+			
+			sw.WriteLine("[Editor Specific]");		// This is where custom area name definition gets stored in project file
+			sw.WriteLine("CustomAreaNames=" + string.Join(",", AreaNames));
 
             sw.Close();
             project = ProjectState.Exists;


### PR DESCRIPTION
User may define custom area names in the new [Editor Specific] category in their .proj file. If no .proj file is present, defaults to vanilla names
<img width="997" height="661" alt="image" src="https://github.com/user-attachments/assets/8983b4e9-953e-401d-a382-1250232bbf4b" />
<img width="997" height="661" alt="image" src="https://github.com/user-attachments/assets/eb52b4a2-837c-4ec9-9908-50ecb1395db1" />
