### PR TITLE
Allow editing non-enemy objects in OAM Editor

### DIFF
--- a/mage/Editors/FormOam.Designer.cs
+++ b/mage/Editors/FormOam.Designer.cs
@@ -49,6 +49,7 @@
             toolStrip1 = new System.Windows.Forms.ToolStrip();
             button_viewPalette = new System.Windows.Forms.ToolStripButton();
             button_viewVram = new System.Windows.Forms.ToolStripButton();
+            button_loadCommonGraphics = new System.Windows.Forms.ToolStripButton();
             toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             button_gfxZoomIn = new System.Windows.Forms.ToolStripButton();
             button_gfxZoomOut = new System.Windows.Forms.ToolStripButton();
@@ -376,7 +377,7 @@
             // toolStrip1
             // 
             toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { button_viewPalette, button_viewVram, toolStripSeparator1, button_gfxZoomIn, button_gfxZoomOut, label_gfxZoom });
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { button_viewPalette, button_viewVram, button_loadCommonGraphics, toolStripSeparator1, button_gfxZoomIn, button_gfxZoomOut, label_gfxZoom });
             toolStrip1.Location = new System.Drawing.Point(4, 19);
             toolStrip1.Name = "toolStrip1";
             toolStrip1.Size = new System.Drawing.Size(529, 25);
@@ -402,6 +403,15 @@
             button_viewVram.Size = new System.Drawing.Size(23, 22);
             button_viewVram.Text = "View entire VRAM";
             button_viewVram.Click += button_viewVram_Click;
+            // 
+            // button_loadCommonGraphics
+            // 
+            button_loadCommonGraphics.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            button_loadCommonGraphics.ImageTransparentColor = System.Drawing.Color.Magenta;
+            button_loadCommonGraphics.Name = "button_loadCommonGraphics";
+            button_loadCommonGraphics.Size = new System.Drawing.Size(23, 22);
+            button_loadCommonGraphics.Text = "Load Common Graphics";
+            button_loadCommonGraphics.Click += button_loadCommonGraphics_Click;
             // 
             // toolStripSeparator1
             // 
@@ -1295,5 +1305,6 @@
         private System.Windows.Forms.ToolStripMenuItem button_exportAnimation;
         private System.Windows.Forms.ToolStripMenuItem button_importOam;
         private System.Windows.Forms.ToolStripMenuItem button_exportAssembly;
+        private System.Windows.Forms.ToolStripButton button_loadCommonGraphics;
     }
 }

--- a/mage/Editors/FormOam.Designer.cs
+++ b/mage/Editors/FormOam.Designer.cs
@@ -407,6 +407,7 @@
             // button_loadCommonGraphics
             // 
             button_loadCommonGraphics.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            button_loadCommonGraphics.Image = Properties.Resources.toolbar_minimap;
             button_loadCommonGraphics.ImageTransparentColor = System.Drawing.Color.Magenta;
             button_loadCommonGraphics.Name = "button_loadCommonGraphics";
             button_loadCommonGraphics.Size = new System.Drawing.Size(23, 22);

--- a/mage/Editors/FormOam.cs
+++ b/mage/Editors/FormOam.cs
@@ -158,6 +158,13 @@ public partial class FormOam : Form
             loadCommonGraphics = value;
             Program.Config.OamEditorLoadCommonGraphics = value;
             button_loadCommonGraphics.Checked = value;
+
+            if (!loading)
+            {
+                Status.LoadNew();
+                DrawNewGFX();
+                LoadPalette(0);
+            }
         }
     }
     private bool loadCommonGraphics = true;
@@ -220,11 +227,12 @@ public partial class FormOam : Form
         ViewOrigin = Program.Config.OamEditorViewOrigin;
         ViewPartOutline = Program.Config.OamEditorViewPartOutlines;
         ViewPalette = Program.Config.OamEditorViewPalette;
-        LoadCommonGraphics = Program.Config.OamEditorLoadCommonGraphics;
         UpdateGfxZoom(Program.Config.OamEditorGfxZoom);
         UpdateOamZoom(Program.Config.OamEditorOamZoom);
 
         loading = true;
+
+        LoadCommonGraphics = true; // We don't want to draw/reload graphics during initalization so this must come after `loading = true`
 
         textBox_imageOffset.Text = Hex.ToString(gfxOffset);
         textBox_palOffset.Text = Hex.ToString(palOffset);
@@ -482,6 +490,7 @@ public partial class FormOam : Form
     private void DrawImage()
     {
         if (!ViewVram) gfxImage = gfxObject.Draw4bpp(palette, 0, true);
+        else if (ViewVram && !LoadCommonGraphics) gfxImage = gfxObject.Draw4bpp(palette, 0, true); // A weird edge-case where this condition would render a blank Vram Viewer
         else gfxImage = vram.VramGFX.Draw15bpp(vram.palette, selectedPaletteRow, true);
         gfxView_gfx.TileImage = gfxImage;
     }
@@ -498,13 +507,8 @@ public partial class FormOam : Form
 
     private void button_viewPalette_Click(object sender, EventArgs e) => ViewPalette = !button_viewPalette.Checked;
     private void button_viewVram_Click(object sender, EventArgs e) => ViewVram = !button_viewVram.Checked;
-    private void button_loadCommonGraphics_Click(object sender, EventArgs e)
-    {
-        LoadCommonGraphics = !button_loadCommonGraphics.Checked;
-        Status.LoadNew();
-        DrawNewGFX();
-        LoadPalette(0);
-    }
+    private void button_loadCommonGraphics_Click(object sender, EventArgs e) => LoadCommonGraphics = !button_loadCommonGraphics.Checked;
+
 
     private void checkBox_compressed_CheckedChanged(object sender, EventArgs e)
     {
@@ -518,15 +522,6 @@ public partial class FormOam : Form
     private void gfxView_gfx_MouseMove(object sender, TileDisplay.TileDisplayArgs e)
     {
         int offset = ViewVram ? 0 : 16;
-        if (ViewVram && LoadCommonGraphics)
-        {
-            offset = 16;
-        }
-        else if (!ViewVram && !LoadCommonGraphics)
-        {
-            offset = 0;
-        }
-
         int tileNum = e.TileIndexPosition.X + (e.TileIndexPosition.Y + offset) * 32;
         statusLabel_coor.Text = Hex.ToString(tileNum);
 
@@ -559,15 +554,6 @@ public partial class FormOam : Form
     private void gfxView_gfx_TileMouseDown(object sender, mage.Controls.TileDisplay.TileDisplayArgs e)
     {
         int offset = ViewVram ? 0 : 16;
-        if (ViewVram && LoadCommonGraphics)
-        {
-            offset = 16;
-        }
-        else if (!ViewVram && !LoadCommonGraphics)
-        {
-            offset = 0;
-        }
-
         int tileNum = e.TileIndexPosition.X + (e.TileIndexPosition.Y + offset) * 32;
 
         if (SelectedPartIndex == -1) return;

--- a/mage/Editors/FormOam.cs
+++ b/mage/Editors/FormOam.cs
@@ -522,6 +522,11 @@ public partial class FormOam : Form
     private void gfxView_gfx_MouseMove(object sender, TileDisplay.TileDisplayArgs e)
     {
         int offset = ViewVram ? 0 : 16;
+        if (!ViewVram)
+        {
+            if (LoadCommonGraphics) offset = 16;
+            else offset = 0;
+        }
         int tileNum = e.TileIndexPosition.X + (e.TileIndexPosition.Y + offset) * 32;
         statusLabel_coor.Text = Hex.ToString(tileNum);
 
@@ -554,6 +559,11 @@ public partial class FormOam : Form
     private void gfxView_gfx_TileMouseDown(object sender, mage.Controls.TileDisplay.TileDisplayArgs e)
     {
         int offset = ViewVram ? 0 : 16;
+        if (!ViewVram)
+        {
+            if (LoadCommonGraphics) offset = 16;
+            else offset = 0;
+        }
         int tileNum = e.TileIndexPosition.X + (e.TileIndexPosition.Y + offset) * 32;
 
         if (SelectedPartIndex == -1) return;

--- a/mage/Editors/FormOam.resx
+++ b/mage/Editors/FormOam.resx
@@ -127,13 +127,13 @@
   <data name="button_viewVram.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFpSURBVDhPxZJrS8JwFMb9aH2FkZREdKGwIGnqUNiMQEIK
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFpSURBVDhPxZJrS8JwFMb9Zn2GkZREdKGwIGnqUNiMQEIK
         ohARl92Mksa8REYRFmVgL7qRJAld/ABBb3rhOzdPO+efcyUE2oseeBgc9vzOw9lsfxbnVqeWstVaQKmC
         tGs4+QLi9hP4tyrg23wEYaMM3tUSuOP3wMduwRW9Bil2WcMcAUKZgh7Jv0Gn7gkXdALg5m7sXLwAAkjJ
         V+hGY/NnDCDuPNMgWGwZxeecplErpZZRI6GTL4BxMBQGE+XvgHgpTM9Go0HBrLGrCRgKHjMAXhv1WwNd
         19saDM4eMQB+qp/CjU1j2GpN0+idgZkDBhDWH2hg3YhBkO2mMfhRmTCNckj7DMDLdzTAYKIsm5UpnBLo
         iVsp+L5mAuy+DANMR29oYG1ANS0N6vV6W4NeIcUArsgVDToV51UZgPMo6uRykf6s8YVzGA2dwvBc3rjy
-        IR3KEchBv7gHff6sUTttbFaB86AVlQD/LJvtE6hCd0rPhX9KAAAAAElFTkSuQmCC
+        IR3KEchBv7gHff6sUTttbFaB86AVlQD/LJvtE6Ttd0n4eM6yAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="button_frameDown.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -160,9 +160,6 @@
         0AgqRvSORJ7WWoPaaTXUk9VQjVcxonck/j0ofgDmetgt0HdVSAAAAABJRU5ErkJggg==
 </value>
   </data>
-  <metadata name="toolStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>503, 17</value>
-  </metadata>
   <metadata name="toolStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>503, 17</value>
   </metadata>

--- a/mage/Editors/FormOam.resx
+++ b/mage/Editors/FormOam.resx
@@ -127,13 +127,13 @@
   <data name="button_viewVram.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFpSURBVDhPxZLbS8JwFMf963ofSUlEFwoLkqYOhc0IJKQg
-        ChFx2c0oacxLZBRhUQb20I0kSejiHxD00oNvbp52zi/nSgi0h77wZXDY93O+nM32Z3FudWopW60FlCpI
-        u4aTLyBuP4F/qwK+zUcQNsrgXS2BO34PfOwWXNFrkGKXNcwRIJQp6JH8G3TqnnBBJwBu7sbOxQsggJR8
-        hW40Nn/GAOLOMw2CxZZRfM5pGrVSahk1Ejr5AhgHQ2EwUf4OiJfC9Gw0GhTMGruagKHgMQPgtVG/NdB1
-        va3B4OwRA+Cn+inc2DSGrdY0jd4ZmDlgAGH9gQbWjRgE2W4agx+VCdMoh7TPALx8RwMMJsqyWZnCKYGe
-        uJWC72smwO7LMMB09IYG1gZU09KgXq+3NegVUgzgilzRoFNxXpUBOI+iTi4X6c8aXziH0dApDM/ljSsf
-        0qEcgRz0i3vQ588atdPGZhU4D1pRCfDPstk+AbxAd1CWFLlIAAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFpSURBVDhPxZJrS8JwFMb9aH2FkZREdKGwIGnqUNiMQEIK
+        ohARl92Mksa8REYRFmVgL7qRJAld/ABBb3rhOzdPO+efcyUE2oseeBgc9vzOw9lsfxbnVqeWstVaQKmC
+        tGs4+QLi9hP4tyrg23wEYaMM3tUSuOP3wMduwRW9Bil2WcMcAUKZgh7Jv0Gn7gkXdALg5m7sXLwAAkjJ
+        V+hGY/NnDCDuPNMgWGwZxeecplErpZZRI6GTL4BxMBQGE+XvgHgpTM9Go0HBrLGrCRgKHjMAXhv1WwNd
+        19saDM4eMQB+qp/CjU1j2GpN0+idgZkDBhDWH2hg3YhBkO2mMfhRmTCNckj7DMDLdzTAYKIsm5UpnBLo
+        iVsp+L5mAuy+DANMR29oYG1ANS0N6vV6W4NeIcUArsgVDToV51UZgPMo6uRykf6s8YVzGA2dwvBc3rjy
+        IR3KEchBv7gHff6sUTttbFaB86AVlQD/LJvtE6hCd0rPhX9KAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="button_frameDown.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -160,6 +160,9 @@
         0AgqRvSORJ7WWoPaaTXUk9VQjVcxonck/j0ofgDmetgt0HdVSAAAAABJRU5ErkJggg==
 </value>
   </data>
+  <metadata name="toolStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>503, 17</value>
+  </metadata>
   <metadata name="toolStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>503, 17</value>
   </metadata>
@@ -267,6 +270,9 @@
   </data>
   <metadata name="contextMenu_oamNoSelection.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>877, 17</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>137</value>
   </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/mage/Options/Config.cs
+++ b/mage/Options/Config.cs
@@ -61,6 +61,7 @@ public class Config
     public bool OamEditorViewPartOutlines { get; set; } = true;
     public bool OamEditorViewPalette { get; set; } = true;
     public bool OamEditorViewVram { get; set; } = false;
+    public bool OamEditorLoadCommonGraphics { get; set; } = true;
     public int OamEditorGfxZoom { get; set; } = 2;
     public int OamEditorOamZoom { get; set; } = 2;
     #endregion

--- a/mage/VramObj.cs
+++ b/mage/VramObj.cs
@@ -14,14 +14,18 @@ namespace mage
 
         private Dictionary<int, int> rowAssignments;
         private ByteStream romStream;
-        
-        public VramObj(GFX gfx, Palette pal)
+
+        public VramObj(GFX gfx, Palette pal, Boolean loadCommonGraphics = true)
         {
             romStream = ROM.Stream;
-            LoadGenericData();
+            int dstOffset = 0;
+            if (loadCommonGraphics)
+            {
+                dstOffset += 0x4000;
+            }
+            LoadGenericData(loadCommonGraphics);
 
             // copy gfx
-            int dstOffset = 0x4000;
             int length = Math.Min(0x8000 - dstOffset, gfx.data.Length);
             Buffer.BlockCopy(gfx.data, 0, objTiles, dstOffset, length);
 
@@ -29,10 +33,10 @@ namespace mage
             palette.Copy(pal, 0, 8 % 16, pal.Rows);
         }
 
-        public VramObj(Spriteset spriteset)
+        public VramObj(Spriteset spriteset, Boolean loadCommonGraphics = true)
         {
             romStream = ROM.Stream;
-            LoadGenericData();
+            LoadGenericData(loadCommonGraphics);
 
             rowAssignments = new Dictionary<int, int>();
             for (int i = 0; i < spriteset.spriteIDs.Count; i++)
@@ -43,10 +47,10 @@ namespace mage
             }
         }
 
-        public VramObj(byte spriteID, bool primary)
+        public VramObj(byte spriteID, bool primary, Boolean loadCommonGraphics = true)
         {
             romStream = ROM.Stream;
-            LoadGenericData();
+            LoadGenericData(loadCommonGraphics);
 
             rowAssignments = new Dictionary<int, int>();
             if (!primary)
@@ -61,12 +65,14 @@ namespace mage
             LoadSprite(spriteID, 0);
         }
 
-        private void LoadGenericData()
+        private void LoadGenericData(bool loadCommonGraphics)
         {
             // gfx
             objTiles = new byte[0x8000];
-            byte[] data = ROM.GenericSpriteGfx.data;
-            Buffer.BlockCopy(data, 0, objTiles, 0x800, data.Length);
+            if (loadCommonGraphics){
+                byte[] data = ROM.GenericSpriteGfx.data;
+                Buffer.BlockCopy(data, 0, objTiles, 0x800, data.Length);
+            }
 
             // palette
             palette = new Palette(16);


### PR DESCRIPTION
Testing was primarily performed with MF, some additional testing with MZM may be necessary.

* Adds a button to OAM Editor for toggling the use of common in-game OBJ Graphics
* Fixes a bug when copying palettes for compressed data in the OAM Editor where the computed length of the palette rows exceeds the maximum array length of the currently loaded palette.

MF Values used for testing
gfx `73DC20` Compressed
pal `740D08`
oam `740AB8`

gfx `56F71C` Compressed (Can cause palette row computation error before fix is applied)