### PR TITLE
Ignore textbox key presses in OAM editor

### DIFF
--- a/mage/Editors/FormOam.cs
+++ b/mage/Editors/FormOam.cs
@@ -417,6 +417,19 @@ public partial class FormOam : Form
 
     private void KeyPressed(object sender, KeyEventArgs e)
     {
+        // Ignore key presses when a textbox is selected
+        var control = ActiveControl;
+        while (true)
+        {
+            if (control is TextBox)
+                return;
+
+            if (control is ContainerControl container && container.ActiveControl != null)
+                control = container.ActiveControl;
+            else
+                break;
+        }
+
         switch (e.KeyCode)
         {
             case Keys.H:


### PR DESCRIPTION
The KeyPressed event triggers even when textboxes are selected. So if you're trying to cut (ctrl+x) or paste (ctrl+v) something (or press any of the shortcut keys, with or without ctrl pressed), it ends up activating the shortcut when you don't intend to

I ran into this when pasting addresses into the textbox and it would ask me if I wanted to save the changes (because it would Y-flip a part)